### PR TITLE
[38기 이진혁] Modal 구현 완료

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Modal = () => {
+  return <div></div>;
+};
+
+export default Modal;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,7 +1,115 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
+import './Modal.scss';
 
-const Modal = () => {
-  return <div></div>;
+const Modal = props => {
+  const { close, contents } = props;
+
+  const token = localStorage.getItem('token');
+
+  const [count, setCount] = useState(1);
+
+  const BackHandler = e => {
+    e.stopPropagation();
+    close();
+  };
+
+  const postItemInfo = () => {
+    if (!token) {
+      alert('회원전용 서비스입니다!');
+    }
+  };
+
+  if (contents.type === 'cart') {
+    return (
+      <div className="modalBackground">
+        <div className="cartModalBox">
+          <div className="cartModalTopBox">
+            <p className="cartContentsItem">우삼겹 순두부찌개</p>
+            <div className="cartCountBox">
+              <p className="cartItemPrice">8900원</p>
+              <div className="cartCount">
+                {count <= 1 ? (
+                  <FontAwesomeIcon
+                    className="cartMinusIcon"
+                    style={{ color: 'lightGray' }}
+                    icon={faMinus}
+                  />
+                ) : (
+                  <FontAwesomeIcon
+                    className="cartMinusIcon"
+                    icon={faMinus}
+                    onClick={() => {
+                      setCount(count - 1);
+                    }}
+                  />
+                )}
+                <p className="cartCounts">{count}</p>
+                <FontAwesomeIcon
+                  className="cartPlusIcon"
+                  icon={faPlus}
+                  onClick={() => {
+                    setCount(count + 1);
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="cartModalMiddleBox">
+            <p className="cartSumText">합계</p>
+            <p className="cartSumVar">{count * 8900 + '원'}</p>
+          </div>
+          {token ? (
+            <p className="cartPointBox">
+              <span className="cartPointTag">적립</span>구매시 0원 적립
+            </p>
+          ) : (
+            <p className="cartPointBox">
+              <span className="cartPointTag">적립</span>로그인 후, 회원할인가와
+              적립혜택 제공
+            </p>
+          )}
+          <div className="cartModalBottomBox">
+            <button
+              className="cartModalLeftBtn"
+              onClick={e => {
+                BackHandler(e);
+              }}
+            >
+              취소
+            </button>
+            <button
+              className="cartModalRightBtn"
+              onClick={() => {
+                postItemInfo();
+              }}
+            >
+              장바구니 담기
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  } else if (contents.type === 'normal') {
+    return (
+      <div className="modalBackground">
+        <div className="modalBox">
+          <div className="modalContentsBox">
+            <p className="modalContentsText">{contents.title}</p>
+          </div>
+          <div
+            className="modalConfirmBox"
+            onClick={e => {
+              BackHandler(e);
+            }}
+          >
+            <button className="modalConfirmBtn">확인</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 };
 
 export default Modal;

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -1,0 +1,1 @@
+@import '../../styles/variables.scss';

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -1,1 +1,179 @@
 @import '../../styles/variables.scss';
+
+.modalBackground {
+  @include flex(center, center, null);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background-color: rgba(100, 100, 100, 0.8);
+  z-index: 1000;
+
+  .modalBox {
+    width: 360px;
+    min-height: 150px;
+    background-color: white;
+    border-radius: 10px;
+
+    .modalContentsBox {
+      width: 360px;
+      height: 122px;
+      padding: 40px 30px;
+
+      .modalContentsText {
+        font-size: 16px;
+        text-align: center;
+        line-height: 1.5;
+        font-weight: 600;
+      }
+    }
+
+    .modalConfirmBox {
+      @include flex(center, center, null);
+      width: 360px;
+      height: 55px;
+      border-top: 1px solid rgb(245, 245, 245);
+
+      .modalConfirmBtn {
+        width: 64px;
+        border: none;
+        font-size: 16px;
+        font-weight: 600;
+        color: $primary-color;
+        background-color: white;
+        cursor: pointer;
+      }
+    }
+  }
+
+  .cartModalBox {
+    @include flex(center, center, column);
+    height: auto;
+    width: 440px;
+    overflow-x: hidden;
+    padding: 30px;
+    border-radius: 12px;
+    box-shadow: none;
+    background: white;
+
+    .cartModalTopBox {
+      width: 100%;
+      max-height: 355px;
+      min-height: 130px;
+
+      .cartContentsItem {
+        font-size: 16px;
+        line-height: 19px;
+        color: rgb(51, 51, 51);
+        overflow: hidden;
+        word-break: break-all;
+      }
+
+      .cartCountBox {
+        @include flex(space-between, center, null);
+        width: 100%;
+        margin-top: 15px;
+
+        .cartItemPrice {
+          font-weight: bold;
+          font-size: 20px;
+          color: rgb(51, 51, 51);
+          line-height: 21px;
+        }
+
+        .cartCount {
+          @include flex(space-between, center, null);
+          width: 100px;
+          height: 36px;
+          border: 1px solid rgb(221, 223, 225);
+          border-radius: 3px;
+          padding: 0 10px;
+
+          .cartCounts {
+            font-size: 18px;
+            font-weight: 600;
+            margin-top: 5px;
+          }
+        }
+      }
+    }
+    .cartModalMiddleBox {
+      @include flex(space-between, center, null);
+      width: 100%;
+
+      .cartSumText {
+        font-size: 16px;
+        line-height: 24px;
+        font-weight: 600;
+      }
+
+      .cartSumVar {
+        font-size: 26px;
+        font-weight: 700;
+        line-height: 24px;
+      }
+    }
+
+    .cartModalBottomBox {
+      @include flex(space-between, center, null);
+      width: 100%;
+      margin-top: 25px;
+
+      .cartModalLeftBtn {
+        display: block;
+        padding: 0px 10px;
+        padding-top: 4px;
+        text-align: center;
+        overflow: hidden;
+        width: 185px;
+        height: 52px;
+        border-radius: 3px;
+        color: rgb(51, 51, 51);
+        background-color: rgb(255, 255, 255);
+        border: 1px solid rgb(221, 221, 221);
+        font-weight: bold;
+        font-size: 16px;
+        cursor: pointer;
+      }
+
+      .cartModalRightBtn {
+        display: block;
+        padding: 0px 10px;
+        padding-top: 4px;
+        text-align: center;
+        overflow: hidden;
+        width: 185px;
+        height: 52px;
+        border-radius: 3px;
+        color: rgb(255, 255, 255);
+        background-color: $primary-color;
+        border: 0px none;
+        font-weight: bold;
+        font-size: 16px;
+        cursor: pointer;
+      }
+    }
+    .cartPointBox {
+      @include flex(end, center, null);
+      width: 100%;
+      font-size: 15px;
+      line-height: 1.33;
+      margin-top: 5px;
+      color: rgb(51, 51, 51);
+
+      .cartPointTag {
+        width: 38px;
+        height: 18px;
+        margin-right: 6px;
+        border-radius: 9px;
+        background-color: rgb(255, 191, 0);
+        font-size: 11px;
+        font-weight: 600;
+        line-height: 20px;
+        color: rgb(255, 255, 255);
+        text-align: center;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 각각의 페이지에서 사용할 modal을 모듈화해서 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. contents.type에 따라 모달의 형식을 두 가지로 분기하였습니다.
- contents 타입을 검사해 normal 또는 cart인 경우 해당하는 모달을 띄우는 방식으로 구현했습니다
- 현재는 api 가 나오지 않아 장바구니에 담는 함수 fetch나 컴포넌트를 구성하는 항목들이 정적데이터로 구성되어 있지만 api가 나오는대로 해당 사항들은 바로 fix 할 예정입니다
- 해당 상품에 대한 갯수는 count라는 변수로 관리하고 있으며 만약 count가 1이하일 경우 더 이상 수량을 줄이지 못하도록 색깔을 바꿔주고 함수를 걸어주지 않았습니다
- 현재는 회원인 경우에만 구입할 수 있도록 로직을 구현하고 있기 때문에 localstorage에 토큰이 있는지 없는지를 기준으로 만약 토큰이 없다면 장바구니에 담는 fetch 로직이 아니라 간단하게 회원만 가능하다고 alert를 띄워주었습니다.



<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 한 컴포넌트에서 switch case나 if문으로 return하는 값을 다르게 해주는 것도 컴포넌트를 재사용한다고 생각했었는데 잘못알고 있었던 것 같습니다. 이번 기회에 컴포넌트 재사용에 대해 많이 알게 되었습니다!

<br />

## :: 기타 질문 및 특이 사항

