### PR TITLE
[38기 이진혁] 공용 캐러셀

### DIFF
--- a/public/data/DATA.json
+++ b/public/data/DATA.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": 0,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+  {
+    "id": 1,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+  {
+    "id": 2,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+  {
+    "id": 3,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+  {
+    "id": 4,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+
+  {
+    "id": 5,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+  {
+    "id": 6,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+  {
+    "id": 7,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+  {
+    "id": 8,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  },
+  {
+    "id": 9,
+    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+    "name": "asdasd"
+  }
+]

--- a/public/data/DATA.json
+++ b/public/data/DATA.json
@@ -1,53 +1,81 @@
-[
-  {
-    "id": 0,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
-  {
-    "id": 1,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
-  {
-    "id": 2,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
-  {
-    "id": 3,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
-  {
-    "id": 4,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
+{
+  "bannerCarousel": [
+    {
+      "id": 0,
+      "img": "https://product-image.kurly.com/cdn-cgi/image/format=auto/banner/main/pc/img/b088f8ec-9120-4e17-8223-6aeb0a683824.jpg"
+    },
+    {
+      "id": 1,
+      "img": "https://product-image.kurly.com/cdn-cgi/image/format=auto/banner/main/pc/img/b088f8ec-9120-4e17-8223-6aeb0a683824.jpg"
+    },
+    {
+      "id": 2,
+      "img": "https://product-image.kurly.com/cdn-cgi/image/format=auto/banner/main/pc/img/b088f8ec-9120-4e17-8223-6aeb0a683824.jpg"
+    },
+    {
+      "id": 3,
+      "img": "https://product-image.kurly.com/cdn-cgi/image/format=auto/banner/main/pc/img/b088f8ec-9120-4e17-8223-6aeb0a683824.jpg"
+    },
+    {
+      "id": 4,
+      "img": "https://product-image.kurly.com/cdn-cgi/image/format=auto/banner/main/pc/img/b088f8ec-9120-4e17-8223-6aeb0a683824.jpg"
+    },
+    {
+      "id": 5,
+      "img": "https://product-image.kurly.com/cdn-cgi/image/format=auto/banner/main/pc/img/b088f8ec-9120-4e17-8223-6aeb0a683824.jpg"
+    }
+  ],
+  "itemCarousel": [
+    {
+      "id": 0,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
+    {
+      "id": 1,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
+    {
+      "id": 2,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
+    {
+      "id": 3,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
+    {
+      "id": 4,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
 
-  {
-    "id": 5,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
-  {
-    "id": 6,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
-  {
-    "id": 7,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
-  {
-    "id": 8,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  },
-  {
-    "id": 9,
-    "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
-    "name": "asdasd"
-  }
-]
+    {
+      "id": 5,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
+    {
+      "id": 6,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
+    {
+      "id": 7,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
+    {
+      "id": 8,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    },
+    {
+      "id": 9,
+      "img": "https://img-cf.kurly.com/cdn-cgi/image/width=400,format=auto/shop/data/goods/1654152673579l0.jpg",
+      "name": "asdasd"
+    }
+  ]
+}

--- a/src/components/Carousel/BannerCarousel/BannerCarousel.js
+++ b/src/components/Carousel/BannerCarousel/BannerCarousel.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import './BannerCarousel.scss';
+
+const BannerCarousel = () => {
+  return <div className="bannerCarousel"></div>;
+};
+
+export default BannerCarousel;

--- a/src/components/Carousel/BannerCarousel/BannerCarousel.js
+++ b/src/components/Carousel/BannerCarousel/BannerCarousel.js
@@ -1,8 +1,66 @@
-import React from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  MdOutlineArrowForwardIos,
+  MdOutlineArrowBackIos,
+} from 'react-icons/md';
 import './BannerCarousel.scss';
 
 const BannerCarousel = () => {
-  return <div className="bannerCarousel"></div>;
+  const [slide, setSlide] = useState(0);
+
+  const [bannerList, setBannerList] = useState([]);
+
+  const slideRef = useRef(null);
+
+  const page = bannerList.length;
+
+  useEffect(() => {
+    fetch('data/DATA.json', {
+      method: 'GET',
+    })
+      .then(res => res.json())
+      .then(data => {
+        setBannerList(data.bannerCarousel);
+      });
+  }, []);
+
+  useEffect(() => {
+    slideRef.current.style.transition = 'all 0.4s ease-in-out';
+    slideRef.current.style.transform = `translateX(-${slide * 100}%)`;
+  }, [slide]);
+
+  const showNextSlide = () => {
+    setSlide(slide => slide + 1);
+  };
+  const showPrevSlide = () => {
+    setSlide(slide => slide - 1);
+  };
+
+  return (
+    <div className="bannerCarousel">
+      <div className="bannerCarouselBox" ref={slideRef}>
+        {bannerList.map((banner, idx) => (
+          <img
+            className="bannerImg"
+            src={banner.img}
+            alt="배너이미지"
+            key={banner.id}
+          />
+        ))}
+      </div>
+
+      {slide !== 0 && (
+        <div className="slideMinusBtn" onClick={showPrevSlide}>
+          <MdOutlineArrowBackIos className="slideMinusIcon" />
+        </div>
+      )}
+      {slide + 1 !== page && (
+        <div className="slidePlusBtn" onClick={showNextSlide}>
+          <MdOutlineArrowForwardIos className="slidePlusIcon" />
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default BannerCarousel;

--- a/src/components/Carousel/BannerCarousel/BannerCarousel.scss
+++ b/src/components/Carousel/BannerCarousel/BannerCarousel.scss
@@ -1,0 +1,1 @@
+@import '../../../styles/variables.scss';

--- a/src/components/Carousel/BannerCarousel/BannerCarousel.scss
+++ b/src/components/Carousel/BannerCarousel/BannerCarousel.scss
@@ -1,1 +1,67 @@
 @import '../../../styles/variables.scss';
+
+.bannerCarousel {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+
+  .bannerCarouselBox {
+    @include flex(space-between, center, null);
+
+    .bannerImg {
+      width: 100%;
+      height: 370px;
+      display: block;
+    }
+  }
+
+  .slideMinusBtn {
+    @include flex(center, center, null);
+    position: absolute;
+    top: 0px;
+    bottom: 0px;
+    right: 50%;
+    margin: auto 590px auto 0px;
+    z-index: 10;
+    width: 52px;
+    height: 52px;
+    transition: all 0.5s ease 0s;
+    border-radius: 52px;
+    opacity: 0.3;
+    background-color: black;
+    box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    cursor: pointer;
+
+    .slideMinusIcon {
+      color: white;
+      width: 25px;
+      height: 25px;
+      margin-right: 3px;
+    }
+  }
+
+  .slidePlusBtn {
+    @include flex(center, center, null);
+    position: absolute;
+    top: 0px;
+    bottom: 0px;
+    left: 50%;
+    margin: auto 0px auto 590px;
+    z-index: 10;
+    width: 52px;
+    height: 52px;
+    opacity: 0.3;
+    border-radius: 52px;
+    transition: all 0.5s ease 0s;
+    background-color: black;
+    box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    cursor: pointer;
+
+    .slidePlusIcon {
+      color: white;
+      width: 25px;
+      height: 25px;
+      margin-left: 3px;
+    }
+  }
+}

--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -8,7 +8,7 @@ const Carousel = ({ type, contents }) => {
     banner: <BannerCarousel contents={contents} />,
     item: <ItemCarousel contents={contents} />,
   };
-  return <>{type[carousel]}</>;
+  return <>{carousel[type]}</>;
 };
 
 export default Carousel;

--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -1,8 +1,14 @@
 import React from 'react';
+import BannerCarousel from './BannerCarousel/BannerCarousel';
+import ItemCarousel from './ItemCarousel/ItemCarousel';
 import './Carousel.scss';
 
-const Carousel = () => {
-  return <div className="carousel"></div>;
+const Carousel = ({ type, contents }) => {
+  const carousel = {
+    banner: <BannerCarousel contents={contents} />,
+    item: <ItemCarousel contents={contents} />,
+  };
+  return <>{type[carousel]}</>;
 };
 
 export default Carousel;

--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import './Carousel.scss';
+
+const Carousel = () => {
+  return <div className="carousel"></div>;
+};
+
+export default Carousel;

--- a/src/components/Carousel/Carousel.scss
+++ b/src/components/Carousel/Carousel.scss
@@ -1,0 +1,1 @@
+@import '../../styles/variables.scss';

--- a/src/components/Carousel/ItemCarousel/ItemCarousel.js
+++ b/src/components/Carousel/ItemCarousel/ItemCarousel.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import './ItemCarousel.scss';
+
+const ItemCarousel = () => {
+  return <div className="itemCarousel"></div>;
+};
+
+export default ItemCarousel;

--- a/src/components/Carousel/ItemCarousel/ItemCarousel.js
+++ b/src/components/Carousel/ItemCarousel/ItemCarousel.js
@@ -20,7 +20,7 @@ const ItemCarousel = ({ contents }) => {
     })
       .then(res => res.json())
       .then(data => {
-        setItemList(data);
+        setItemList(data.itemCarousel);
       });
   }, []);
 

--- a/src/components/Carousel/ItemCarousel/ItemCarousel.js
+++ b/src/components/Carousel/ItemCarousel/ItemCarousel.js
@@ -1,8 +1,65 @@
-import React from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  MdOutlineArrowForwardIos,
+  MdOutlineArrowBackIos,
+} from 'react-icons/md';
 import './ItemCarousel.scss';
 
-const ItemCarousel = () => {
-  return <div className="itemCarousel"></div>;
+const ItemCarousel = ({ contents }) => {
+  const [slide, setSlide] = useState(0);
+
+  const [itemList, setItemList] = useState([]);
+
+  const slideRef = useRef(null);
+
+  const page = Math.ceil(itemList.length / 4);
+
+  useEffect(() => {
+    fetch('data/DATA.json', {
+      method: 'GET',
+    })
+      .then(res => res.json())
+      .then(data => {
+        setItemList(data);
+      });
+  }, []);
+
+  useEffect(() => {
+    slideRef.current.style.transition = 'all 0.4s ease-in-out';
+    slideRef.current.style.transform = `translateX(-${slide * 40.3}%)`;
+  }, [slide]);
+
+  const showNextSlide = () => {
+    setSlide(slide => slide + 1);
+  };
+  const showPrevSlide = () => {
+    setSlide(slide => slide - 1);
+  };
+
+  return (
+    <div className="itemCarousel">
+      <p className="itemTitle">{contents}</p>
+      <div className="itemCarouselBox">
+        <div className="itemList" ref={slideRef}>
+          {itemList.map((item, idx) => (
+            <div className="items" key={item.id}>
+              <img src={item.img} width="249px" alt="테스트 사진" />
+            </div>
+          ))}
+        </div>
+      </div>
+      {slide !== 0 && (
+        <div className="slideMinusBtn" onClick={showPrevSlide}>
+          <MdOutlineArrowBackIos className="slideMinusIcon" />
+        </div>
+      )}
+      {slide + 1 !== page && (
+        <div className="slidePlusBtn" onClick={showNextSlide}>
+          <MdOutlineArrowForwardIos className="slidePlusIcon" />
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default ItemCarousel;

--- a/src/components/Carousel/ItemCarousel/ItemCarousel.scss
+++ b/src/components/Carousel/ItemCarousel/ItemCarousel.scss
@@ -1,0 +1,1 @@
+@import '../../../styles/variables.scss';

--- a/src/components/Carousel/ItemCarousel/ItemCarousel.scss
+++ b/src/components/Carousel/ItemCarousel/ItemCarousel.scss
@@ -1,1 +1,77 @@
 @import '../../../styles/variables.scss';
+
+.itemCarousel {
+  position: relative;
+
+  .itemTitle {
+    color: $text-color;
+    font-size: 28px;
+    line-height: 1.15;
+    letter-spacing: -0.26px;
+    font-weight: 600;
+    text-align: center;
+    margin-bottom: 30px;
+  }
+
+  .itemCarouselBox {
+    max-width: 1050px;
+    height: 434px;
+    overflow: hidden;
+
+    .itemList {
+      @include flex(space-between, center, null);
+      width: 252%;
+
+      .items {
+        width: 249px;
+        height: 412px;
+      }
+    }
+  }
+
+  .slideMinusBtn {
+    @include flex(center, center, null);
+    position: absolute;
+    z-index: 100;
+    border: 0px;
+    outline: 0px;
+    width: 50px;
+    height: 50px;
+    border-radius: 60px;
+    top: calc(50% - 20px);
+    left: 0;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    cursor: pointer;
+
+    .slideMinusIcon {
+      width: 25px;
+      height: 25px;
+      margin-right: 3px;
+    }
+  }
+
+  .slidePlusBtn {
+    @include flex(center, center, null);
+    position: absolute;
+    z-index: 100;
+    border: 0px;
+    outline: 0px;
+    width: 50px;
+    height: 50px;
+    border-radius: 60px;
+    top: calc(50% - 20px);
+    right: -50px;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    cursor: pointer;
+
+    .slidePlusIcon {
+      width: 25px;
+      height: 25px;
+      margin-left: 3px;
+    }
+  }
+}

--- a/src/pages/Main/MainBannerCarousel/MainBannerCarousel.js
+++ b/src/pages/Main/MainBannerCarousel/MainBannerCarousel.js
@@ -1,7 +1,12 @@
 import React from 'react';
+import Carousel from '../../../components/Carousel/Carousel';
 import './MainBannerCarousel.scss';
 const MainBannerCarousel = () => {
-  return <div className="mainBannerCarousel">메인케러셀 자리</div>;
+  return (
+    <div className="mainBannerCarousel">
+      <Carousel type="banner" />
+    </div>
+  );
 };
 
 export default MainBannerCarousel;

--- a/src/pages/Main/MainBannerCarousel/MainBannerCarousel.scss
+++ b/src/pages/Main/MainBannerCarousel/MainBannerCarousel.scss
@@ -4,5 +4,4 @@
   width: 100%;
   height: 370px;
   margin-top: 160px;
-  border: 2px solid $text-color;
 }

--- a/src/pages/Main/MainContentsBox/MainRecommendItem/MainRecommendItem.js
+++ b/src/pages/Main/MainContentsBox/MainRecommendItem/MainRecommendItem.js
@@ -1,8 +1,13 @@
 import React from 'react';
+import Carousel from '../../../../components/Carousel/Carousel';
 import './MainRecommendItem.scss';
 
 const MainRecommendItem = () => {
-  return <div className="mainRecommendItem">메인 상품 추천 자리</div>;
+  return (
+    <div className="mainRecommendItem">
+      <Carousel type="item" contents="이 상품은 어때요?" />
+    </div>
+  );
 };
 
 export default MainRecommendItem;

--- a/src/pages/Main/MainContentsBox/MainRecommendItem/MainRecommendItem.scss
+++ b/src/pages/Main/MainContentsBox/MainRecommendItem/MainRecommendItem.scss
@@ -2,8 +2,6 @@
 
 .mainRecommendItem {
   width: 1050px;
-  height: 590px;
-  border: 2px solid $text-color;
   margin: 0 auto;
   margin-top: 100px;
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 메인페이지에서 사용할 공용 캐러셀 구현
- computed property를 이용해 두 개의 컴포넌트중  type에 맞는 컴포넌트를 리턴합니다

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. ItemCarousel
- contents를 props로 받고 있으며 이 props는 상품들의 제목을 나타냅니다(ex 이 상품들은 어때요? , 컬리가 추천하는 베스트!)
- 서버로부터 받아오는 상품데이터의 길이를 4로 나누어(한 슬라이드에 나타나는 아이템의 총 갯수가 4) page라는 변수에 저장했습니다
- 만약 현재 슬라이드가 0이라면 전의 슬라이드를 불러오는 minusIcon을 비활성화 시켰고 현재 슬라이드가 page와 일치하면 다음 슬라이드를 불러오는  plusIcon을 비활성화해서 더이상 넘어갈 수 없도록 구현했습니다.
- 현재는 임의의 img만 들어가 있지만 공용 컴포넌트 items가 merge되면 items를 mapping하여 구현할 생각입니다.


2. BannerCarousel
- BannerCarousel의 경우 contents를  받아올 필요가 없기 때문에 props가 없습니다.
- ItemCarousel과 마찬가지로 만약 현재 슬라이드가 0이라면 전의 슬라이드를 불러오는 minusIcon을 비활성화 시켰고 현재 슬라이드가 page와 일치하면 다음 슬라이드를 불러오는  plusIcon을 비활성화해서 더이상 넘어갈 수 없도록 구현했습니다.




<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)


<br />

## :: 기타 질문 및 특이 사항

